### PR TITLE
Feat Command-line Interfaces

### DIFF
--- a/api/http-reverse-proxy-golang.go
+++ b/api/http-reverse-proxy-golang.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -11,13 +12,20 @@ import (
 )
 
 var (
-	apiTargetURL     string = "https://api.github.com"              // Set the default target URL here
-	maxRequestSize   int64  = 10 * 1024 * 1024                      // 10 MB
-	requestRateLimit        = rate.NewLimiter(rate.Limit(100), 100) // 100 requests per second
-	concurrencyLimit        = make(chan struct{}, 10)               // 10 concurrent requests
+	apiTargetURL     string
+	maxRequestSize   int64
+	requestRateLimit float64
+	concurrencyLimit int
 )
 
 func main() {
+	// Parse command-line flags
+	flag.StringVar(&apiTargetURL, "apiTargetURL", "https://api.github.com", "API target URL")
+	flag.Int64Var(&maxRequestSize, "maxRequestSize", 10*1024*1024, "Maximum request size")
+	flag.Float64Var(&requestRateLimit, "requestRateLimit", 100, "Request rate limit (requests per second)")
+	flag.IntVar(&concurrencyLimit, "concurrencyLimit", 10, "Concurrency limit (maximum concurrent requests)")
+	flag.Parse()
+
 	// Create a new logger instance with the desired configuration.
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.TextFormatter{
@@ -27,20 +35,26 @@ func main() {
 	// Set the logger output to os.Stdout.
 	logger.SetOutput(os.Stdout)
 
+	// Create a rate limiter based on the request rate limit
+	requestRateLimiter := rate.NewLimiter(rate.Limit(requestRateLimit), concurrencyLimit)
+
+	// Create a semaphore for concurrency limiting
+	concurrencyLimiter := make(chan struct{}, concurrencyLimit)
+
 	// The API will be proxied to the specified target URL.
 	http.HandleFunc("/api/", func(w http.ResponseWriter, r *http.Request) {
 		// Set the maximum request size limit
 		r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 
 		// Check if the request rate exceeds the limit
-		if !requestRateLimit.Allow() {
+		if !requestRateLimiter.Allow() {
 			http.Error(w, "Request rate limit exceeded", http.StatusTooManyRequests)
 			return
 		}
 
 		// Acquire a semaphore slot
-		concurrencyLimit <- struct{}{}
-		defer func() { <-concurrencyLimit }()
+		concurrencyLimiter <- struct{}{}
+		defer func() { <-concurrencyLimiter }()
 
 		// Handle the request
 		handleProxy(w, r, logger)


### PR DESCRIPTION
[+] chore(http-reverse-proxy-golang.go): refactor code to use command-line flags for configuration
[+] feat(http-reverse-proxy-golang.go): add support for command-line flags to configure API target URL, maximum request size, request rate limit, and concurrency limit