### PR TITLE
Remove ReadTimeout & WriteTimeout

### DIFF
--- a/api/http-reverse-proxy-golang.go
+++ b/api/http-reverse-proxy-golang.go
@@ -79,11 +79,9 @@ func main() {
 
 	// Create a server instance with custom settings
 	server := &http.Server{
-		Addr:         fmt.Sprintf(":%d", serverPort),
-		Handler:      nil, // Use default handler (Mux)
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
-		TLSConfig:    &tls.Config{MinVersion: tls.VersionTLS12},
+		Addr:      fmt.Sprintf(":%d", serverPort),
+		Handler:   nil, // Use default handler (Mux)
+		TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 	}
 
 	// Start the server with or without TLS


### PR DESCRIPTION
[+] chore(http-reverse-proxy-golang): remove unused ReadTimeout and WriteTimeout settings in server configuration

More stable now for response "text/event-stream" in server-side not a fake network response